### PR TITLE
Make the library do C++ things when compiling as C++

### DIFF
--- a/include/fastmod.h
+++ b/include/fastmod.h
@@ -19,28 +19,21 @@
 
 #ifdef _MSC_VER
 #include <intrin.h>
+#endif
 
 #ifdef __cplusplus
 namespace {
 namespace fastmod {
 #endif
+
+#ifdef _MSC_VER
 
 // __umulh is only available in x64 mode under Visual Studio: don't compile to 32-bit!
 FASTMOD_API uint64_t mul128_u32(uint64_t lowbits, uint32_t d) {
   return __umulh(lowbits, d);
 }
 
-#ifdef __cplusplus
-} // fastmod
-}
-#endif
-
 #else // _MSC_VER NOT defined
-
-#ifdef __cpluslus
-namespace {
-namespace fastmod {
-#endif
 
 FASTMOD_API uint64_t mul128_u32(uint64_t lowbits, uint32_t d) {
   return ((__uint128_t)lowbits * d) >> 64;
@@ -50,10 +43,6 @@ FASTMOD_API uint64_t mul128_s32(uint64_t lowbits, int32_t d) {
   return ((__int128_t)lowbits * d) >> 64;
 }
 
-#ifdef __cplusplus
-} // fastmod
-}
-#endif // __cplusplus
 #endif // _MSC_VER
 
 /**
@@ -65,10 +54,6 @@ FASTMOD_API uint64_t mul128_s32(uint64_t lowbits, int32_t d) {
  *
  **/
 
-#ifdef __cplusplus
-namespace {
-namespace fastmod {
-#endif 
 
 // M = ceil( (1<<64) / d ), d > 0
 FASTMOD_API uint64_t computeM_u32(uint32_t d) {


### PR DESCRIPTION
This PR makes use of the preprocessor to add C++ specific things to the library when compiling for C++.

What this PR adds:
* A macro `FASTMOD_API` that expands to `static inline` when compiling for C, but to nothing when compiling for C++.
* A namespace `fastmod` within an unnamed namespace for what I believe to do the same as `static inline` in C, this effect is probably only applicable on C++11 and above though(unless I'm reading the section about this on cppreference.com wrong).

There were also some comments added to make the preprocessor logic easier to follow(imo). If there's anything you'd like me to change, please tell me.