### PR TITLE
64-bit fastdiv & mod for MSVC

### DIFF
--- a/include/fastmod.h
+++ b/include/fastmod.h
@@ -55,63 +55,63 @@ FASTMOD_API uint64_t mul128_s32(uint64_t lowbits, int32_t d) {
 // Visual Studio lacks support for 128-bit integers so they simulated are using
 // multiword arithmatic and VS specific intrinsics.
 
-    FASTMOD_API uint64_t add128_u64(
-        uint64_t M_hi, uint64_t M_lo, uint64_t addend, uint64_t* sum_hi
-    ) {
-        uint64_t sum_lo;
+FASTMOD_API uint64_t add128_u64(
+    uint64_t M_hi, uint64_t M_lo, uint64_t addend, uint64_t* sum_hi
+  ) {
+  uint64_t sum_lo;
 
-        bool carry = _addcarry_u64(0, M_lo, addend, &sum_lo);
-        _addcarry_u64(carry, M_hi, 0, sum_hi); // Encourages 'adc'
+  bool carry = _addcarry_u64(0, M_lo, addend, &sum_lo);
+  _addcarry_u64(carry, M_hi, 0, sum_hi); // Encourages 'adc'
 
-        return sum_lo;
-    }
+  return sum_lo;
+}
 
-    FASTMOD_API uint64_t div128_u64(
-        uint64_t dividend_hi, uint64_t dividend_lo, uint64_t divisor, uint64_t* quotient_hi
-    ) {
-        *quotient_hi = dividend_hi / divisor;
-        uint64_t remainder_hi = dividend_hi % divisor;
+FASTMOD_API uint64_t div128_u64(
+    uint64_t dividend_hi, uint64_t dividend_lo, uint64_t divisor, uint64_t* quotient_hi
+  ) {
+  *quotient_hi = dividend_hi / divisor;
+  uint64_t remainder_hi = dividend_hi % divisor;
 
-        // When long div starts to consider the low dividend,
-        // the high part would have became its remainder.
-        // Prevents an arithmetic exception when _udiv128 calculates a >64-bit quotient
-        uint64_t remainder; // Discard
-        return _udiv128(remainder_hi, dividend_lo, divisor, &remainder);
-    }
+  // When long div starts to consider the low dividend,
+  // the high part would have became its remainder.
+  // Prevents an arithmetic exception when _udiv128 calculates a >64-bit quotient
+  uint64_t remainder; // Discard
+  return _udiv128(remainder_hi, dividend_lo, divisor, &remainder);
+}
 
-    // Multiplies the 128-bit integer by d and returns the lower 128-bits of the product
-    FASTMOD_API uint64_t mul128_u64_lo(
-        uint64_t M_hi, uint64_t M_lo, uint64_t d, uint64_t* product_hi
-    ) {
-        uint64_t lowbits_hi;
-        uint64_t lowbits_lo = _umul128(M_lo, d, &lowbits_hi);
+// Multiplies the 128-bit integer by d and returns the lower 128-bits of the product
+FASTMOD_API uint64_t mul128_u64_lo(
+    uint64_t M_hi, uint64_t M_lo, uint64_t d, uint64_t* product_hi
+  ) {
+  uint64_t lowbits_hi;
+  uint64_t lowbits_lo = _umul128(M_lo, d, &lowbits_hi);
 
-        *product_hi = lowbits_hi + (M_hi * d);
+  *product_hi = lowbits_hi + (M_hi * d);
 
-        return lowbits_lo;
-    }
+  return lowbits_lo;
+}
 
-    // Multiplies the 128-bit integer by d and returns the highest 64-bits of the product
-    FASTMOD_API uint64_t mul128_u64_hi(uint64_t lowbits_hi, uint64_t lowbits_lo, uint64_t d) {
-        uint64_t bottomHalf_hi = __umulh(lowbits_lo, d);
+// Multiplies the 128-bit integer by d and returns the highest 64-bits of the product
+FASTMOD_API uint64_t mul128_u64_hi(uint64_t lowbits_hi, uint64_t lowbits_lo, uint64_t d) {
+  uint64_t bottomHalf_hi = __umulh(lowbits_lo, d);
 
-        uint64_t topHalf_hi;
-        uint64_t topHalf_lo = _umul128(lowbits_hi, d, &topHalf_hi);
+  uint64_t topHalf_hi;
+  uint64_t topHalf_lo = _umul128(lowbits_hi, d, &topHalf_hi);
 
-        uint64_t bothHalves_hi;
-        add128_u64(topHalf_hi, topHalf_lo, bottomHalf_hi, &bothHalves_hi);
+  uint64_t bothHalves_hi;
+  add128_u64(topHalf_hi, topHalf_lo, bottomHalf_hi, &bothHalves_hi);
 
-        return bothHalves_hi;
-    }
+  return bothHalves_hi;
+}
 
-    FASTMOD_API bool isgreater_u128(uint64_t a_hi, uint64_t a_low, uint64_t b_hi, uint64_t b_low) {
-        // Only when low is greater, high equality should return true
-        uint64_t discard;
-        bool borrowWhenEql = _subborrow_u64(0, b_low, a_low, &discard);
+FASTMOD_API bool isgreater_u128(uint64_t a_hi, uint64_t a_low, uint64_t b_hi, uint64_t b_low) {
+  // Only when low is greater, high equality should return true
+  uint64_t discard;
+  bool borrowWhenEql = _subborrow_u64(0, b_low, a_low, &discard);
 
-        // borrow(b - (a + C_in)) = C_in? (a >= b) : (a > b)
-        return _subborrow_u64(borrowWhenEql, b_hi, a_hi, &discard);
-    }
+  // borrow(b - (a + C_in)) = C_in? (a >= b) : (a > b)
+  return _subborrow_u64(borrowWhenEql, b_hi, a_hi, &discard);
+}
 
 #endif // End MSVC 64-bit support
 #else // _MSC_VER NOT defined

--- a/tests/cppincludetest1.cpp
+++ b/tests/cppincludetest1.cpp
@@ -15,8 +15,8 @@ bool testunsigned64(uint64_t min, uint64_t max, bool verbose) {
       printf("skipping d = 0\n");
       continue;
     }
-#ifndef _MSC_VER
-    __uint128_t M64 = computeM_u64(d);
+
+    auto M64 = computeM_u64(d);
     if (verbose)
       printf("d = %" PRIu64 " (unsigned 64-bit) ", d);
     else
@@ -37,7 +37,7 @@ bool testunsigned64(uint64_t min, uint64_t max, bool verbose) {
         return false;
       }
     }
-#endif
+
     if (verbose)
       printf("ok!\n");
   }

--- a/tests/cppincludetest2.cpp
+++ b/tests/cppincludetest2.cpp
@@ -119,7 +119,7 @@ bool testsigned(int32_t min, int32_t max, bool verbose) {
       printf("skipping d = 0 as it cannot be supported\n");
       continue;
     }
-    if (d == -2147483648) {
+    if (d == INT32_MIN) {
       printf("skipping d = -2147483648 as it is unsupported\n");
       continue;
     }
@@ -166,7 +166,7 @@ bool testdivsigned(int32_t min, int32_t max, bool verbose) {
   printf("\n==Testing divsigned with min = %d and max = %d\n", min, max);
   assert(min != max + 1); // infinite loop!
   size_t count = 0;
-  static_assert(int32_t(-2147483648) < int32_t(2147483647));
+  static_assert(int32_t(INT32_MIN) < int32_t(2147483647));
   for (int32_t d = min; (d <= max) && (d >= min); d++) {
     if (d == 0) {
       printf("skipping d = 0\n");
@@ -205,7 +205,7 @@ bool testdivsigned(int32_t min, int32_t max, bool verbose) {
             d, a);
         printf("expected %d div %d = %d \n", a, d, computedDiv);
         printf("got %d div %d = %d \n", a, d, computedFastDiv);
-        if (d == -2147483648) {
+        if (d == INT32_MIN) {
           printf("Note: d = -2147483648 is unsupported\n");
         } else {
           return false;
@@ -235,7 +235,7 @@ int main(int argc, char *argv[]) {
   }
 
   isok = isok && testdivsigned(0x7ffffff8, 0x7fffffff, verbose);
-  isok = isok && testdivsigned(-0x80000000, -0x7ffffff8, verbose);
+  isok = isok && testdivsigned(INT32_MIN, -0x7ffffff8, verbose);
   isok = isok && testdivsigned(2, 10, verbose);
   isok = isok && testdivsigned(-10, -2, verbose);
   isok = isok && testunsigned64(1, 0x10, verbose);
@@ -251,7 +251,7 @@ int main(int argc, char *argv[]) {
   isok = isok && testsigned(-8, -1, verbose);
   isok = isok && testsigned(1, 8, verbose);
   isok = isok && testsigned(0x7ffffff8, 0x7fffffff, verbose);
-  isok = isok && testsigned(-0x80000000, -0x7ffffff8, verbose);
+  isok = isok && testsigned(INT32_MIN, -0x7ffffff8, verbose);
   for (int k = 0; k < 100; k++) {
     int32_t x = rand();
     isok = isok && testsigned(x, x, verbose);

--- a/tests/unit.c
+++ b/tests/unit.c
@@ -9,6 +9,9 @@
 #ifdef __cplusplus
 using namespace fastmod;
 #endif
+#ifdef _MSC_VER
+typedef fastmod_u128_t __uint128_t;
+#endif
 
 bool testunsigned64(uint64_t min, uint64_t max, bool verbose) {
   for (uint64_t d = min; (d <= max) && (d >= min); d++) {
@@ -130,7 +133,7 @@ bool testsigned(int32_t min, int32_t max, bool verbose) {
       printf("skipping d = 0 as it cannot be supported\n");
       continue;
     }
-    if (d == -2147483648) {
+    if (d == INT32_MIN) {
       printf("skipping d = -2147483648 as it is unsupported\n");
       continue;
     }
@@ -181,7 +184,7 @@ bool testdivsigned(int32_t min, int32_t max, bool verbose) {
       printf("skipping d = -1 as it is not supported\n");
       continue;
     }
-    if (d == -2147483648) {
+    if (d == INT32_MIN) {
       printf("skipping d = -2147483648 as it is unsupported\n");
       continue;
     }
@@ -228,7 +231,7 @@ int main(int argc, char *argv[]) {
   isok = isok && testunsigned64(UINT64_C(0xffffffffff00000), UINT64_C(0xffffffffff00000) + 0x100, verbose);
   isok = isok && testunsigned(1, 8, verbose);
   isok = isok && testunsigned(0xfffffff8, 0xffffffff, verbose);
-  isok = isok && testdivsigned(-0x80000000, -0x7ffffff8, verbose);
+  isok = isok && testdivsigned(INT32_MIN, -0x7ffffff8, verbose);
   isok = isok && testdivsigned(2, 10, verbose);
   isok = isok && testdivsigned(0x7ffffff8, 0x7fffffff, verbose);
   isok = isok && testdivsigned(-10, -2, verbose);
@@ -239,7 +242,7 @@ int main(int argc, char *argv[]) {
   isok = isok && testsigned(-8, -1, verbose);
   isok = isok && testsigned(1, 8, verbose);
   isok = isok && testsigned(0x7ffffff8, 0x7fffffff, verbose);
-  isok = isok && testsigned(-0x80000000, -0x7ffffff8, verbose);
+  isok = isok && testsigned(INT32_MIN, -0x7ffffff8, verbose);
   for (int k = 0; k < 100; k++) {
     int32_t x = rand();
     isok = isok && testsigned(x, x, verbose);


### PR DESCRIPTION
Added 64-bit fastdiv & mod support for MSVC via multi-word arithmetic and VS specific intrinsics. I needed to add additional functions for that. This produces very similar asm output to GCC/Clang's __uint128_t.

I also had to slightly modify the tests to make it compatible with MSVC:
- Removed `#ifndef _MSC_VER` directives
- `__uint128_t` => `auto`
- Literals `-2147483648` & `-0x80000000` => `INT32_MIN` (to prevent overflow)
- Added VS compatible `doNotOptimizeAway`

![MSVC_PassedTest](https://github.com/user-attachments/assets/e6867b94-e2a2-44d5-b6f8-4f8e281e4d66)
